### PR TITLE
Stop VScode complaining about Mocha functions not existing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY ./package*.json ./
 
 RUN npm ci --production=true
 
-COPY ./tsconfig.json ./
+COPY ./tsconfig.prod.json ./
 
 RUN npm install -g typescript
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ./src ./src
 #TEMPORARY (docker-compose has an issue with .dockerignore files)
 RUN rm -rf ./src/test
 
-RUN tsc
+RUN tsc -p tsconfig.prod.json
 
 COPY ./database.json ./
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@ COPY ./package*.json ./
 
 RUN npm ci --production=false
 
-COPY ./tsconfig.test.json ./
+COPY ./tsconfig.json ./
 
 RUN npm install -g typescript
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ RUN npm install -g typescript
 
 COPY ./src ./src
 
-RUN tsc -p tsconfig.test.json
+RUN tsc -p tsconfig.json
 
 COPY ./database.json ./
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "types": ["node"],
+        "types": ["node", "mocha"],
         "moduleResolution": "node",
         "esModuleInterop": true,
         "target": "esnext",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "types": ["node", "mocha"],
+        "types": ["node"],
         "moduleResolution": "node",
         "esModuleInterop": true,
         "target": "esnext",


### PR DESCRIPTION
VSCode would complain in test files about mocha function missing, because mocha types weren't included in the default tsconfig.json. Swapping some file names around fixes this.